### PR TITLE
Improve Windows scripts

### DIFF
--- a/dev.jeka.core/src/main/java/META-INF/bin/jeka.bat
+++ b/dev.jeka.core/src/main/java/META-INF/bin/jeka.bat
@@ -13,6 +13,15 @@ if not "%JAVA_HOME%" == "" set "JAVA_CMD=%JAVA_HOME%\bin\java"
 if exist %cd%\jeka\boot set "LOCAL_BUILD_DIR=.\jeka\boot\*;"
 if "%JEKA_HOME%" == "" set "JEKA_HOME=%~dp0"
 
+rem Ensure that the Jeka jar is actually in JEKA_HOME
+if not exist %JEKA_HOME%\dev.jeka.jeka-core.jar (
+	echo Could not find "dev.jeka.jeka-core.jar" in "%JEKA_HOME%"
+	echo Please ensure JEKA_HOME points to the correct directory
+	echo or that the distrib.zip file has been extracted fully
+	rem Pause before exiting so the user can read the message first
+	pause
+	exit /b 1
+)
 set "COMMAND="%JAVA_CMD%" %JEKA_OPTS% -cp "%LOCAL_BUILD_DIR%%JEKA_HOME%\dev.jeka.jeka-core.jar" dev.jeka.core.tool.Main %*"
 if not "%JEKA_ECHO_CMD%" == "" (
 	@echo on

--- a/dev.jeka.core/src/main/java/META-INF/bin/jeka.bat
+++ b/dev.jeka.core/src/main/java/META-INF/bin/jeka.bat
@@ -11,6 +11,8 @@ if "%JAVA_HOME%" == "" set "JAVA_CMD=java"
 if not "%JAVA_HOME%" == "" set "JAVA_CMD=%JAVA_HOME%\bin\java"
 
 if exist %cd%\jeka\boot set "LOCAL_BUILD_DIR=.\jeka\boot\*;"
+if "%JEKA_HOME%" == "" set "JEKA_HOME=%~dp0"
+
 set "COMMAND="%JAVA_CMD%" %JEKA_OPTS% -cp "%LOCAL_BUILD_DIR%%JEKA_HOME%\dev.jeka.jeka-core.jar" dev.jeka.core.tool.Main %*"
 if not "%JEKA_ECHO_CMD%" == "" (
 	@echo on

--- a/dev.jeka.core/src/main/java/META-INF/bin/wrapper/jekaw.bat
+++ b/dev.jeka.core/src/main/java/META-INF/bin/wrapper/jekaw.bat
@@ -11,7 +11,7 @@ if "%JAVA_HOME%" == "" set "JAVA_CMD=java"
 if not "%JAVA_HOME%" == "" set "JAVA_CMD=%JAVA_HOME%\bin\java"
 
 if exist %cd%\jeka\boot set "LOCAL_BUILD_DIR=.\jeka\boot\*;"
-set "COMMAND="%JAVA_CMD%" %JEKA_OPTS% -cp "%LOCAL_BUILD_DIR%%~dp0jeka\wrapper\*" dev.jeka.core.wrapper.Booter %~dp0 %*"
+set "COMMAND="%JAVA_CMD%" %JEKA_OPTS% -cp "%LOCAL_BUILD_DIR%%~dp0jeka\wrapper\*" dev.jeka.core.wrapper.Booter "%~dp0." %*"
 if not "%JEKA_ECHO_CMD%" == "" (
 	@echo on
 	echo %COMMAND%


### PR DESCRIPTION
The PR for #125 

Allows running `jeka.bat` without `JEKA_HOME` being present, as well as warning when the Jeka jar can't be found rather than the slightly more cryptic `Error: Could not find or load main class dev.jeka.core.tool.Main`.
Also fixes running `jekaw.bat` in directories with spaces in the path.