### PR TITLE
Fix Windows boot directory detection

### DIFF
--- a/dev.jeka.core/src/main/java/META-INF/bin/jeka.bat
+++ b/dev.jeka.core/src/main/java/META-INF/bin/jeka.bat
@@ -10,11 +10,11 @@ if not "%JEKA_JDK%" == "" set "JAVA_HOME=%JEKA_JDK%"
 if "%JAVA_HOME%" == "" set "JAVA_CMD=java"
 if not "%JAVA_HOME%" == "" set "JAVA_CMD=%JAVA_HOME%\bin\java"
 
-if exist %cd%\jeka\boot set "LOCAL_BUILD_DIR=.\jeka\boot\*;"
+if exist "%cd%\jeka\boot" set "LOCAL_BUILD_DIR=.\jeka\boot\*;"
 if "%JEKA_HOME%" == "" set "JEKA_HOME=%~dp0"
 
 rem Ensure that the Jeka jar is actually in JEKA_HOME
-if not exist %JEKA_HOME%\dev.jeka.jeka-core.jar (
+if not exist "%JEKA_HOME%\dev.jeka.jeka-core.jar" (
 	echo Could not find "dev.jeka.jeka-core.jar" in "%JEKA_HOME%"
 	echo Please ensure JEKA_HOME points to the correct directory
 	echo or that the distrib.zip file has been extracted fully

--- a/dev.jeka.core/src/main/java/META-INF/bin/wrapper/jekaw.bat
+++ b/dev.jeka.core/src/main/java/META-INF/bin/wrapper/jekaw.bat
@@ -10,7 +10,7 @@ if not "%JEKA_JDK%" == "" set "JAVA_HOME=%JEKA_JDK%"
 if "%JAVA_HOME%" == "" set "JAVA_CMD=java"
 if not "%JAVA_HOME%" == "" set "JAVA_CMD=%JAVA_HOME%\bin\java"
 
-if exist %cd%\jeka\boot set "LOCAL_BUILD_DIR=.\jeka\boot\*;"
+if exist "%cd%\jeka\boot" set "LOCAL_BUILD_DIR=.\jeka\boot\*;"
 set "COMMAND="%JAVA_CMD%" %JEKA_OPTS% -cp "%LOCAL_BUILD_DIR%%~dp0jeka\wrapper\*" dev.jeka.core.wrapper.Booter "%~dp0." %*"
 if not "%JEKA_ECHO_CMD%" == "" (
 	@echo on


### PR DESCRIPTION
When Jeka is run from a path containing spaces, the boot directory would appear to not exist as it would only check up to the first space in the path.