### PR TITLE
Fix artifact checksums being overcalculated

### DIFF
--- a/dev.jeka.core/src/main/java/dev/jeka/core/api/java/project/JkJavaProjectPackTasks.java
+++ b/dev.jeka.core/src/main/java/dev/jeka/core/api/java/project/JkJavaProjectPackTasks.java
@@ -132,7 +132,7 @@ public class JkJavaProjectPackTasks {
     void checksum(Path fileToChecksum) {
         for (String algo : checksumAlgorithms) {
             JkLog.startTask("Creating checksum " + algo + " for file " + fileToChecksum);
-            JkPathFile.of(fileToChecksum).checksum(checksumAlgorithms);
+            JkPathFile.of(fileToChecksum).checksum(algo);
             JkLog.endTask();
         }
 


### PR DESCRIPTION
Saves recalculating all the different checksum calculations as many times as there are different algorithms.