### PR TITLE
Ivy updated to 2.5.0 in .classpath

### DIFF
--- a/dev.jeka.core/.classpath
+++ b/dev.jeka.core/.classpath
@@ -7,7 +7,7 @@
 	<classpathentry kind="lib" path="jeka/libs/provided/bouncycastle-pgp-152.jar"/>
 	<classpathentry kind="lib" path="jeka/libs/provided/classgraph-4.8.41.jar"/>
 	<classpathentry kind="lib" path="jeka/libs/provided/hamcrest-core-1.3.jar"/>
-	<classpathentry kind="lib" path="jeka/libs/provided/ivy-2.4.0.jar"/>
+	<classpathentry kind="lib" path="jeka/libs/provided/ivy-2.5.0.jar"/>
 	<classpathentry kind="lib" path="jeka/libs/provided/junit-4.11.jar"/>
 	<classpathentry kind="lib" path="jeka/boot/commonmark-0.11.0.jar"/>
 	<classpathentry kind="lib" path="jeka/libs/test/jdepend-2.9.1.jar"/>


### PR DESCRIPTION
The repo contains ivy 2.5.0 but `.classpath` still references 2.4.0.

See https://github.com/jerkar/jeka/tree/master/dev.jeka.core/jeka/libs/provided