### PR TITLE
Fix script dependencies not having sources attached in Eclipse 

### DIFF
--- a/dev.jeka.core/src/main/java/dev/jeka/core/api/java/JkJavaVersion.java
+++ b/dev.jeka.core/src/main/java/dev/jeka/core/api/java/JkJavaVersion.java
@@ -42,8 +42,14 @@ public final class JkJavaVersion {
     /** Stands for Java Version  11 */
     public static final JkJavaVersion V11 = JkJavaVersion.of("11");
 
-    /** Stands for Java Version  11 */
+    /** Stands for Java Version  12 */
     public static final JkJavaVersion V12 = JkJavaVersion.of("12");
+
+    /** Stands for Java Version  13 */
+    public static final JkJavaVersion V13 = JkJavaVersion.of("13");
+
+    /** Stands for Java Version  14 */
+    public static final JkJavaVersion V14 = JkJavaVersion.of("14");
 
     private final String value;
 

--- a/dev.jeka.core/src/main/java/dev/jeka/core/api/tooling/eclipse/JkEclipseClasspathGenerator.java
+++ b/dev.jeka.core/src/main/java/dev/jeka/core/api/tooling/eclipse/JkEclipseClasspathGenerator.java
@@ -233,8 +233,7 @@ public final class JkEclipseClasspathGenerator {
 
         // add build dependencies
         if (hasBuildDef() && runDependencyResolver != null) {
-            final Iterable<Path> files = runDependencyResolver.resolve(runDependencies).getFiles();
-            writeFileDepsEntries(writer, files, paths, new Properties(), new Properties());
+            writeDependenciesEntries(writer, runDependencies, runDependencyResolver, paths);
         }
 
         // Write output

--- a/release-note.md
+++ b/release-note.md
@@ -10,7 +10,7 @@
 
 # 0.8.12
 *  Eclipse plugin : Generate specific 'attributes' and 'accessrules' to each dependency.
-*  Fix JkDependencySet#and(Jcd .kDependencySet) 
+*  Fix JkDependencySet#and(JkDependencySet) 
 *  Make build failure on deps resolution failure by default
 *  Move def compiled classes to _jeka/.work_ 
 


### PR DESCRIPTION
IntelliJ already applies project and script dependencies together (via `JkImlGenerator#writeDependencies`) so doesn't have this problem. Also coincidentally allows applying attributes and access rules to script dependencies too (as a mild improvement to #153).