### PR TITLE
Fix Travis building PRs

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -8,6 +8,13 @@
 
 	<property name="bin" location="jeka-bin" />
 
+	<condition property="isPR">
+		<not>
+			<!-- https://docs.travis-ci.com/user/environment-variables/#default-environment-variables -->
+			<equals arg1="false" arg2="${env.TRAVIS_PULL_REQUEST}" casesensitive="false" trim="true" />
+		</not>
+	</condition>
+
 	<fileset id="libs" dir="dev.jeka.core/jeka/libs/provided">
 		<include name='**/*.jar' />
 	</fileset>
@@ -30,7 +37,7 @@
 		</copy>
 	</target>
 
-	<target name="run" depends="bootstrap">
+	<target name="run" depends="bootstrap" unless="isPR">
 		<java classname="dev.jeka.core.tool.Main" dir="dev.jeka.core" fork="true" failonerror="true">
 			<arg line="java#pack publishDocsOnGithubPage java#publish -java#tests.runIT=false -LogMaxLength=100 -LogHeaders" />
 			<classpath>
@@ -40,6 +47,17 @@
 		</java>
 	</target>
 
-	<target name="test" depends="run"/>
+	<target name="runPR" depends="bootstrap" if="isPR">
+		<java classname="dev.jeka.core.tool.Main" dir="dev.jeka.core" fork="true" failonerror="true">
+			<!-- Avoid trying to publish the jar made from a pull request -->
+			<arg line="java#pack -java#tests.runIT=false -LogMaxLength=100 -LogHeaders" />
+			<classpath>
+				<pathelement location="${bin}" />
+				<fileset refid="libs" />
+			</classpath>
+		</java>
+	</target>
+
+	<target name="test" depends="run, runPR"/>
 
 </project>


### PR DESCRIPTION
The PR jars Travis makes don't need to be published (unlike the normal commit ones), so hopefully this should stop it failing.